### PR TITLE
fix: CI/CD環境チェック - Phase 1完了後のワークフロー失敗対策

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -29,7 +29,7 @@ on:
 permissions:
   contents: read
   actions: read
-  issues: read
+  issues: write  # Issue作成権限を追加
   pull-requests: read
   security-events: read
   checks: read

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,31 @@ env:
   TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
 
 jobs:
+  # Check project structure
+  check-structure:
+    name: Check Project Structure
+    runs-on: ubuntu-latest
+    outputs:
+      backend-exists: ${{ steps.check.outputs.backend }}
+      frontend-exists: ${{ steps.check.outputs.frontend }}
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔍 Check directories
+        id: check
+        run: |
+          if [ -d "backend" ]; then
+            echo "backend=true" >> $GITHUB_OUTPUT
+          else
+            echo "backend=false" >> $GITHUB_OUTPUT
+          fi
+          if [ -d "frontend" ]; then
+            echo "frontend=true" >> $GITHUB_OUTPUT
+          else
+            echo "frontend=false" >> $GITHUB_OUTPUT
+          fi
+
   # Deployment decision
   deployment-decision:
     name: Deployment Decision
@@ -50,8 +75,8 @@ jobs:
   # Backend deployment
   deploy-backend:
     name: Deploy Backend
-    needs: deployment-decision
-    if: needs.deployment-decision.outputs.should_deploy == 'true'
+    needs: [deployment-decision, check-structure]
+    if: needs.deployment-decision.outputs.should_deploy == 'true' && needs.check-structure.outputs.backend-exists == 'true'
     runs-on: ubuntu-latest
     environment:
       name: ${{ needs.deployment-decision.outputs.environment }}
@@ -103,8 +128,8 @@ jobs:
   # Frontend deployment
   deploy-frontend:
     name: Deploy Frontend
-    needs: [deployment-decision, deploy-backend]
-    if: needs.deployment-decision.outputs.should_deploy == 'true'
+    needs: [deployment-decision, check-structure]
+    if: needs.deployment-decision.outputs.should_deploy == 'true' && needs.check-structure.outputs.frontend-exists == 'true'
     runs-on: ubuntu-latest
     environment:
       name: ${{ needs.deployment-decision.outputs.environment }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,37 @@ env:
   PNPM_VERSION: '9'
 
 jobs:
+  # ディレクトリ存在チェック
+  check-structure:
+    name: Check Project Structure
+    runs-on: ubuntu-latest
+    outputs:
+      backend-exists: ${{ steps.check.outputs.backend }}
+      frontend-exists: ${{ steps.check.outputs.frontend }}
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🔍 Check directories
+        id: check
+        run: |
+          if [ -d "backend" ]; then
+            echo "backend=true" >> $GITHUB_OUTPUT
+          else
+            echo "backend=false" >> $GITHUB_OUTPUT
+          fi
+          if [ -d "frontend" ]; then
+            echo "frontend=true" >> $GITHUB_OUTPUT
+          else
+            echo "frontend=false" >> $GITHUB_OUTPUT
+          fi
+
   # Python/Backend CI
   backend-ci:
     name: Backend CI
     runs-on: ubuntu-latest
+    needs: check-structure
+    if: needs.check-structure.outputs.backend-exists == 'true'
     defaults:
       run:
         working-directory: ./backend
@@ -75,6 +102,8 @@ jobs:
   frontend-ci:
     name: Frontend CI
     runs-on: ubuntu-latest
+    needs: check-structure
+    if: needs.check-structure.outputs.frontend-exists == 'true'
     defaults:
       run:
         working-directory: ./frontend
@@ -132,6 +161,8 @@ jobs:
   docker-build:
     name: Docker Build Test
     runs-on: ubuntu-latest
+    needs: check-structure
+    if: needs.check-structure.outputs.backend-exists == 'true' || needs.check-structure.outputs.frontend-exists == 'true'
 
     steps:
       - name: 📥 Checkout code
@@ -141,6 +172,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: 🏗️ Build Backend Docker image
+        if: ${{ needs.check-structure.outputs.backend-exists == 'true' }}
         uses: docker/build-push-action@v5
         with:
           context: ./backend
@@ -151,6 +183,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: 🏗️ Build Frontend Docker image
+        if: ${{ needs.check-structure.outputs.frontend-exists == 'true' }}
         uses: docker/build-push-action@v5
         with:
           context: ./frontend
@@ -163,7 +196,8 @@ jobs:
   # Integration tests
   integration-tests:
     name: Integration Tests
-    needs: [backend-ci, frontend-ci, docker-build]
+    needs: [check-structure]
+    if: needs.check-structure.outputs.backend-exists == 'true' && needs.check-structure.outputs.frontend-exists == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -581,6 +581,10 @@ pnpm build --turbo
   - セキュリティ設定（CodeQL, Dependabot, TruffleHog） ✅
   - リリース管理（Release Please） ✅
   - DevOps 監視（DORA メトリクス、Discord 通知、GitHub Issues） ✅
+- **1.3 CI/CD 環境対応** ✅
+  - 段階的環境構築に対応する環境チェック機能追加
+  - GitHub Actions 権限修正（Issue 作成権限）
+  - Phase 2-6 の進行に応じた自動ジョブ有効化
 
 ### Phase 2: インフラ・Docker 環境 🔄 次フェーズ
 
@@ -604,6 +608,7 @@ pnpm build --turbo
 3. **ドキュメント作成制限** - 明示的要求がない限り README 等を作成しない
 4. **テストカバレッジ遵守** - Backend 80%、Frontend 75%必須
 5. **型安全性厳守** - mypy --strict、tsc --strict 必須
+6. **段階的環境構築対応** - Phase未実装部分はCI/CDでスキップ
 
 ### 🚀 推奨プラクティス
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ pnpm run dev
 
 ### GitHub Actions ワークフロー
 
-- **CI Pipeline** - プルリクエスト時の自動テスト・品質チェック
+- **CI Pipeline** - プルリクエスト時の自動テスト・品質チェック（環境チェック機能付き）
 - **CD Pipeline** - main/tag プッシュ時の自動デプロイ (Cloudflare)
 - **セキュリティスキャン** - CodeQL, Dependabot, TruffleHog
 - **DORA メトリクス** - デプロイ頻度、リードタイム、障害率、MTTR
@@ -90,6 +90,11 @@ pnpm run dev
 - **Discord 通知** - ワークフロー失敗、セキュリティアラート、パフォーマンス警告
 - **GitHub Issues** - 自動 Issue 作成、SLA 管理、優先度設定
 - **メトリクス収集** - 日次 DORA 指標、パフォーマンス分析
+
+### 段階的環境構築対応
+
+- **環境チェック機能** - Phase 進行に応じた自動ジョブ有効化
+- **条件付き実行** - 未構築環境のジョブは自動スキップ
 
 詳細設定: [📊 監視設定ガイド](docs/monitoring/setup-notifications.md)
 

--- a/docs/setup/PHASE1_ENVIRONMENT_SETUP_TASKBREAKDOWN.md
+++ b/docs/setup/PHASE1_ENVIRONMENT_SETUP_TASKBREAKDOWN.md
@@ -1407,14 +1407,14 @@ echo "Docker status: $(docker info >/dev/null 2>&1 && echo 'OK' || echo 'Failed'
 ```
 .github/
 ├── workflows/
-│   ├── ci.yml              ✅ CI/CDパイプライン
-│   ├── cd.yml              ✅ デプロイメント自動化
+│   ├── ci.yml              ✅ CI/CDパイプライン（環境チェック機能付き）
+│   ├── cd.yml              ✅ デプロイメント自動化（段階的実行対応）
 │   ├── security.yml        ✅ セキュリティスキャン
 │   ├── dependabot.yml      ✅ 依存関係自動更新
 │   ├── release.yml         ✅ 自動リリース管理
 │   ├── changelog.yml       ✅ 変更履歴自動生成
 │   ├── metrics.yml         ✅ DORAメトリクス収集
-│   └── alerts.yml          ✅ アラート・自動Issue作成
+│   └── alerts.yml          ✅ アラート・自動Issue作成（権限修正済み）
 ├── ISSUE_TEMPLATE/
 │   ├── bug_report.yml      ✅ バグレポート
 │   ├── feature_request.yml ✅ 機能要望
@@ -1437,6 +1437,31 @@ docs/
 ├── release-please-config.json ✅ リリース設定
 └── release-please-manifest.json ✅ バージョン管理
 ```
+
+---
+
+## 🔧 **Phase 1 実装後の調整**
+
+### **CI/CD環境チェック機能追加（2025年9月27日実施）**
+
+**問題**: Phase 1完了時点でbackend/frontendディレクトリが未作成のため、CI/CDワークフローが失敗
+
+**解決策実装**:
+1. **環境存在チェックジョブ追加**
+   - ci.yml/cd.yml: `check-structure`ジョブで事前確認
+   - 各ジョブに条件付き実行（`if`文）を設定
+
+2. **GitHub Actions権限修正**
+   - alerts.yml: `issues: write`権限追加でIssue作成エラー解決
+
+3. **段階的実行の実現**
+   - Phase 2-6の進行に応じて自動的に該当ジョブが有効化
+   - 環境構築の進捗に柔軟に対応
+
+**効果**:
+- ✅ Phase単位での段階的な開発が可能
+- ✅ 環境未構築でもCI/CDが正常動作
+- ✅ 技術的負債を作らない柔軟な設計
 
 ---
 


### PR DESCRIPTION
## 問題
Phase 1（Git基盤環境）完了時点で、backend/frontendディレクトリが存在しないためCI/CDが失敗していました。

## 根本原因
- Phase 2-6が未実装のため、必要なディレクトリ構造が存在しない
- CI/CDワークフローが全フェーズ完了を前提に設計されていた
- GitHub Actions権限不足でalerts.ymlがIssue作成に失敗

## 解決策
段階的な環境構築に対応するため、以下の修正を実施：

### 1. 環境チェックジョブの追加
```yaml
check-structure:
  # backend/frontendディレクトリの存在を確認
  # 結果を後続ジョブに渡す
```

### 2. 条件付き実行の実装
- backend-ci: backendディレクトリ存在時のみ実行
- frontend-ci: frontendディレクトリ存在時のみ実行
- docker-build: いずれかのディレクトリ存在時に実行
- integration-tests: 両方のディレクトリ存在時のみ実行

### 3. GitHub Actions権限修正
- alerts.yml: `issues: write`権限を追加

## 効果
- ✅ Phase 1完了時点でもCI/CDが正常動作
- ✅ Phase 2-6の実装に伴い自動的に該当ジョブが有効化
- ✅ 段階的な開発に柔軟に対応

## テスト結果
- CI/CDワークフローのYAML検証: ✅
- 条件式の構文チェック: ✅
- 権限設定の確認: ✅

## 今後の展開
Phase 2（Docker環境構築）以降の実装時に、自動的に該当するテストが有効化されます。