### PR TITLE
fix: GitHub Actions metrics.ymlのPRイベントタイプエラー修正

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    types: [ opened, closed, merged ]
+    types: [ opened, closed ]  # 'merged'はtypeとして存在しない
   schedule:
     # 毎日午前3時（JST）にメトリクス収集
     - cron: '0 18 * * *'  # UTC 18:00 = JST 03:00


### PR DESCRIPTION
## 概要
GitHub Actions metrics.ymlのpull_requestイベント設定にエラーがあったため修正

## 問題点
- pull_requestイベントのtypesに`merged`を指定していた
- GitHub Actionsでは`merged`は有効なイベントタイプではない

## 修正内容
- typesから`merged`を削除
- `[opened, closed]`のみに変更

## 補足
PRのマージを検知したい場合は、`closed`イベントで`github.event.pull_request.merged == true`をチェックする方式が正しい実装方法です。

## チェックリスト
- [x] コードレビュー完了
- [x] 動作確認済み
- [x] ドキュメント更新不要